### PR TITLE
Optimize load

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "type": "python",
       "request": "launch",
       "program": "${file}",
-      "console": "internalConsole"
+      "console": "internalConsole",
+      "subProcess": true
     }
   ]
 }

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ pyqt5 = "5"
 pyqt5-tools = "5"
 matplotlib = "3.4"
 
+
 [dev-packages]
 autopep8 = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -111,42 +111,39 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:043e83bfc274649c82a6f09836943e4a4aebe5e33656271c7dbf9621dd58b8ec",
-                "sha256:160ccc1bed3a8371bf0d760971f09bfe80a3e18646620e9ded0ad159d9749baa",
-                "sha256:188031f833bbb623637e66006cf75e933e00e7231f67e2b45cf8189612bb5dc3",
-                "sha256:28f15209fb535dd4c504a7762d3bc440779b0e37d50ed810ced209e5cea60d96",
-                "sha256:29fb3dcd0468b7715f8ce2c0c2d9bbbaf5ae686334951343a41bd8d155c6ea27",
-                "sha256:2a6ee9620061b2a722749b391c0d80a0e2ae97290f1b32e28d5a362e21941ee4",
-                "sha256:300321e3985c968e3ae7fbda187237b225f3ffe6528395a5b7a5407f73cf093e",
-                "sha256:32437f0b275c1d09d9c3add782516413e98cd7c09e6baf4715cbce781fc29912",
-                "sha256:3c09418a14471c7ae69ba682e2428cae5b4420a766659605566c0fa6987f6b7e",
-                "sha256:49c6249260890e05b8111ebfc391ed58b3cb4b33e63197b2ec7f776e45330721",
-                "sha256:4cc9b512e9fb590797474f58b7f6d1f1b654b3a94f4fa8558b48ca8b3cfc97cf",
-                "sha256:508b0b513fa1266875524ba8a9ecc27b02ad771fe1704a16314dc1a816a68737",
-                "sha256:50cd26b0cf6664cb3b3dd161ba0a09c9c1343db064e7c69f9f8b551f5104d654",
-                "sha256:5c4193f70f8069550a1788bd0cd3268ab7d3a2b70583dfe3b2e7f421e9aace06",
-                "sha256:5dfe9d6a4c39b8b6edd7990091fea4f852888e41919d0e6722fe78dd421db0eb",
-                "sha256:63571bb7897a584ca3249c86dd01c10bcb5fe4296e3568b2e9c1a55356b6410e",
-                "sha256:75621882d2230ab77fb6a03d4cbccd2038511491076e7964ef87306623aa5272",
-                "sha256:75eb7cadc8da49302f5b659d40ba4f6d94d5045fbd9569c9d058e77b0514c9e4",
-                "sha256:88a5d6b268e9ad18f3533e184744acdaa2e913b13148160b1152300c949bbb5f",
-                "sha256:8a10968963640e75cc0193e1847616ab4c718e83b6938ae74dea44953950f6b7",
-                "sha256:90bec6a86b348b4559b6482e2b684db4a9a7eed1fa054b86115a48d58fbbf62a",
-                "sha256:98339aa9911853f131de11010f6dd94c8cec254d3d1f7261528c3b3e3219f139",
-                "sha256:a99a6b067e5190ac6d12005a4d85aa6227c5606fa93211f86b1dafb16233e57d",
-                "sha256:bffa2eee3b87376cc6b31eee36d05349571c236d1de1175b804b348dc0941e3f",
-                "sha256:c6c2d535a7beb1f8790aaa98fd089ceab2e3dd7ca48aca0af7dc60e6ef93ffe1",
-                "sha256:cc14e7519fab2a4ed87d31f99c31a3796e4e1fe63a86ebdd1c5a1ea78ebd5896",
-                "sha256:dd0482f3fc547f1b1b5d6a8b8e08f63fdc250c58ce688dedd8851e6e26cff0f3",
-                "sha256:dde972a1e11bb7b702ed0e447953e7617723760f420decb97305e66fb4afc54f",
-                "sha256:e54af82d68ef8255535a6cdb353f55d6b8cf418a83e2be3569243787a4f4866f",
-                "sha256:e606e6316911471c8d9b4618e082635cfe98876007556e89ce03d52ff5e8fcf0",
-                "sha256:f41b018f126aac18583956c54544db437f25c7ee4794bcb23eb38bef8e5e192a",
-                "sha256:f8f4625536926a155b80ad2bbff44f8cc59e9f2ad14cdda7acf4c135b4dc8ff2",
-                "sha256:fe52dbe47d9deb69b05084abd4b0df7abb39a3c51957c09f635520abd49b29dd"
+                "sha256:0b78ecfa070460104934e2caf51694ccd00f37d5e5dbe76f021b1b0b0d221823",
+                "sha256:1247ef28387b7bb7f21caf2dbe4767f4f4175df44d30604d42ad9bd701ebb31f",
+                "sha256:1403b4e2181fc72664737d848b60e65150f272fe5a1c1cbc16145ed43884065a",
+                "sha256:170b2a0805c6891ca78c1d96ee72e4c3ed1ae0a992c75444b6ab20ff038ba2cd",
+                "sha256:2e4ed57f45f0aa38beca2a03b6532e70e548faf2debbeb3291cfc9b315d9be8f",
+                "sha256:32fe5b12061f6446adcbb32cf4060a14741f9c21e15aaee59a207b6ce6423469",
+                "sha256:34f3456f530ae8b44231c63082c8899fe9c983fd9b108c997c4b1c8c2d435333",
+                "sha256:4c9c23158b87ed0e70d9a50c67e5c0b3f75bcf2581a8e34668d4e9d7474d76c6",
+                "sha256:5d95668e727c75b3f5088ec7700e260f90ec83f488e4c0aaccb941148b2cd377",
+                "sha256:615d4e328af7204c13ae3d4df7615a13ff60a49cb0d9106fde07f541207883ca",
+                "sha256:69077388c5a4b997442b843dbdc3a85b420fb693ec8e33020bb24d647c164fa5",
+                "sha256:74b85a17528ca60cf98381a5e779fc0264b4a88b46025e6bcbe9621f46bb3e63",
+                "sha256:81225e58ef5fce7f1d80399575576fc5febec79a8a2742e8ef86d7b03beef49f",
+                "sha256:8890b3360f345e8360133bc078d2dacc2843b6ee6059b568781b15b97acbe39f",
+                "sha256:92aafa03da8658609f59f18722b88f0a73a249101169e28415b4fa148caf7e41",
+                "sha256:9864424631775b0c052f3bd98bc2712d131b3e2cd95d1c0c68b91709170890b0",
+                "sha256:9e6f5f50d1eff2f2f752b3089a118aee1ea0da63d56c44f3865681009b0af162",
+                "sha256:a3deb31bc84f2b42584b8c4001c85d1934dbfb4030827110bc36bfd11509b7bf",
+                "sha256:ad010846cdffe7ec27e3f933397f8a8d6c801a48634f419e3d075db27acf5880",
+                "sha256:b1e2312f5b8843a3e4e8224b2b48fe16119617b8fc0a54df8f50098721b5bed2",
+                "sha256:bc988afcea53e6156546e5b2885b7efab089570783d9d82caf1cfd323b0bb3dd",
+                "sha256:c449eb870616a7b62e097982c622d2577b3dbc800aaf8689254ec6e0197cbf1e",
+                "sha256:c74c699b122918a6c4611285cc2cad4a3aafdb135c22a16ec483340ef97d573c",
+                "sha256:c885bfc07f77e8fee3dc879152ba993732601f1f11de248d4f357f0ffea6a6d4",
+                "sha256:e3c3e990274444031482a31280bf48674441e0a5b55ddb168f3a6db3e0c38ec8",
+                "sha256:e4799be6a2d7d3c33699a6f77201836ac975b2e1b98c2a07f66a38f499cb50ce",
+                "sha256:e6c76a87633aa3fa16614b61ccedfae45b91df2767cf097aa9c933932a7ed1e0",
+                "sha256:e89717274b41ebd568cd7943fc9418eeb49b1785b66031bc8a7f6300463c5898",
+                "sha256:f5162ec777ba7138906c9c274353ece5603646c6965570d82905546579573f73",
+                "sha256:fde96af889262e85aa033f8ee1d3241e32bf36228318a61f1ace579df4e8170d"
             ],
             "markers": "python_version < '3.11' and python_version >= '3.7'",
-            "version": "==1.21.3"
+            "version": "==1.21.4"
         },
         "pillow": {
             "hashes": [
@@ -197,11 +194,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c0a7dfcd26825bd4453574c4e7ad04aa095975ce54d04f738fe3a8350fbd223a",
-                "sha256:e0df773d7fa2240322daae7805626dfc5f2d5effb34e1a7be2702c99cfb9f6b1"
+                "sha256:4881e3d2979f27b41a3a2421b10be9cbfa7ce2baa6c7117952222f8bbea6650c",
+                "sha256:9329d1c1b51f0f76371c4ded42c5ec4cc0be18456b22193e0570c2da98ed288b"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.4"
+            "version": "==3.0.5"
         },
         "pyqt5": {
             "hashes": [

--- a/src/pycture/editor/image/__init__.py
+++ b/src/pycture/editor/image/__init__.py
@@ -9,7 +9,7 @@ from .image_loader import ImageLoader
 from .color import Color, RGBColor, GrayScaleLUT
 from .pixel import Pixel
 
-from datetime import datetime
+from datetime import date, datetime
 
 
 class Image(QImage):
@@ -25,23 +25,20 @@ class Image(QImage):
         self.worker = ImageLoader(self)
         self.worker.moveToThread(self.thread)
         self.thread.started.connect(self.worker.run)
-
- 
-        
         self.worker.finished.connect(self.thread.quit)
+
+        self.worker.finished.connect(self.print_time)
+
         self.worker.finished.connect(self.worker.deleteLater)
-        self.worker.finished.connect(self.print_time_ms)
-
         self.thread.finished.connect(self.thread.deleteLater)
-        self.set_timer()
-        self.thread.start()
 
-    def set_timer(self):
         self.then = datetime.now()
 
-    def print_time_ms(self):
+        self.thread.start()
+
+    def print_time(self):
         delta = datetime.now() - self.then
-        print(delta)
+        print("Loading time: ", delta)
 
     def get_brightness(self):
         return list(map(lambda color: self.get_mean(color), Color))
@@ -66,9 +63,7 @@ class Image(QImage):
         return cumulative
 
     def get_mean(self, color: Color):
-        histogram = self.get_histogram(color)
-        mean = sum([h_i * i for i, h_i in enumerate(histogram)])
-        return mean
+        return self.means[color.value]
 
     # Standard deviation
     def get_sd(self, color: Color):

--- a/src/pycture/editor/image/__init__.py
+++ b/src/pycture/editor/image/__init__.py
@@ -9,11 +9,14 @@ from .image_loader import ImageLoader
 from .color import Color, RGBColor, GrayScaleLUT
 from .pixel import Pixel
 
+from datetime import datetime
+
 
 class Image(QImage):
 
     def __init__(self, image: QImage):
         super().__init__(image)
+        self.then = None
         self.setup_image_data()
         self.load_finished = False
 
@@ -22,10 +25,23 @@ class Image(QImage):
         self.worker = ImageLoader(self)
         self.worker.moveToThread(self.thread)
         self.thread.started.connect(self.worker.run)
+
+ 
+        
         self.worker.finished.connect(self.thread.quit)
         self.worker.finished.connect(self.worker.deleteLater)
+        self.worker.finished.connect(self.print_time_ms)
+
         self.thread.finished.connect(self.thread.deleteLater)
+        self.set_timer()
         self.thread.start()
+
+    def set_timer(self):
+        self.then = datetime.now()
+
+    def print_time_ms(self):
+        delta = datetime.now() - self.then
+        print(delta)
 
     def get_brightness(self):
         return list(map(lambda color: self.get_mean(color), Color))
@@ -167,14 +183,14 @@ class Image(QImage):
         for x, y in pixels_coordinates:
             if (not (0 <= x < self.width())):
                 print("Mark pixels: x out of range")
-                return 
-            
+                return
+
             if (not (0 <= y < self.height())):
                 print("Mark pixels: y out of range")
-                return 
+                return
             pixel = Pixel(self.pixel(x, y))
             marked_image.setPixel(x, y, marker_color)
-        
+
         return marked_image
 
     def get_pixels_coordinates(self, treshold: int, rgb_plane: Color):

--- a/src/pycture/editor/image/image_loader.py
+++ b/src/pycture/editor/image/image_loader.py
@@ -1,6 +1,8 @@
 from PyQt5.QtCore import QObject, Signal
+from PyQt5.QtGui import QImage
 from .color import Color, RGBColor, GrayScaleLUT
 from .pixel import Pixel
+from ctypes import string_at
 
 
 class ImageLoader(QObject):
@@ -11,30 +13,33 @@ class ImageLoader(QObject):
         self.image = image
 
     def run(self):
-        image = self.image
+
+        image: QImage = self.image
         image.histograms = [[0] * 256, [0] * 256, [0] * 256, [0] * 256]
         image.ranges = [[255, 0], [255, 0], [255, 0], [255, 0]]
-        # image.means = [0] * 4
-        
-        
-        for x in range(image.width()):
-            for y in range(image.height()):
-                gray_value = 0
-                pixel = Pixel(image.pixel(x, y))
-                for color in RGBColor:
-                    value = pixel.get_color(color)
-                    image.histograms[color.value][value] += 1
-                    # image.means[color.value] += value
-                    gray_value += GrayScaleLUT[color.value][value]
+     
+        size = image.width() * image.height()
 
-                gray_value = round(gray_value)
-                image.histograms[Color.Gray.value][gray_value] += 1
-                # image.means[Color.Gray.value] += gray_value
+        pixels = image.constBits().asstring(size * 4)
+        for i in range(size):
+            i_ = i * 4
+            bgr_bytes = pixels[i_:i_+3]
+            b, g, r = [int.from_bytes(bgr_bytes[j:j+1], 'big') for j in range(3)]
+ 
+            gray_value = 0
+            rgb_values = [r, g, b]
+            for i, value in enumerate(rgb_values):
+                
+                image.histograms[i][value] += 1
 
-        total_pixels = image.width() * image.height()
+                gray_value += GrayScaleLUT[i][value]
+            gray_value = round(gray_value)
+            image.histograms[Color.Gray.value][gray_value] += 1
+    
+        
         image.histograms = list(map(lambda histogram:
                                     list(
-                                        map(lambda x: x / total_pixels, histogram)),
+                                        map(lambda x: x / size, histogram)),
                                     image.histograms
                                     ))
         self.load_means()
@@ -45,7 +50,6 @@ class ImageLoader(QObject):
     def load_means(self):
         image = self.image
         image.means = [self.calculate_mean(hist) for hist in image.histograms]
-
 
 
     def calculate_mean(self, normalized_histogram):


### PR DESCRIPTION
`image_loader` now uses `QImage.constBits()` in order to reduce the loading time by up to 60% 

**Image dimensions:** 5472 x 3648
(gifs cutted)
* Before:
![before](https://user-images.githubusercontent.com/45132495/141175678-9a91c4b9-da4e-41db-afce-b50d7b1c5cf7.gif)
* After: 
![after](https://user-images.githubusercontent.com/45132495/141175710-b0995f1f-0e7b-489f-9d56-9c55f20c8fbd.gif)
 


**Image dimensions:** 1089 x 726
(gifs not cutted)
* Before: 
![before_2](https://user-images.githubusercontent.com/45132495/141177088-e8727a59-35e6-435b-a91f-1c3132a9d10f.gif)
* After: 
![after_2](https://user-images.githubusercontent.com/45132495/141177115-785818bc-c3e7-4d08-80e0-0d40e58fc026.gif)

 